### PR TITLE
Allow Null Date Predicate

### DIFF
--- a/src/predicates/PredicateHelper.cls
+++ b/src/predicates/PredicateHelper.cls
@@ -5,6 +5,9 @@ public with sharing class PredicateHelper {
   }
 
   public static String ToSoqlQueryString(Date d) {
+    if (d == null) {
+      return null;
+    }
     return DateTime.newInstance(d.year(), d.month(), d.day()).format('YYYY-MM-dd');
   }
 


### PR DESCRIPTION
Previously, attempting to set a condition [Date value] NOT EQUALS null, would throw an error. This minor update does a null check which appropriately both fixes the bug and allows a condition for a date to equal/not equal null.